### PR TITLE
Remove redundant line in both Python scripts

### DIFF
--- a/Python_Sample_Exercises/Guess_Number/guess_fixed_number.py
+++ b/Python_Sample_Exercises/Guess_Number/guess_fixed_number.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 answer = 9
 
 max_guess = 3

--- a/Python_Sample_Exercises/Guess_Number/guess_random_number.py
+++ b/Python_Sample_Exercises/Guess_Number/guess_random_number.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 #Import random module to generate random number
 import random
 


### PR DESCRIPTION
This patch removes redundant line "#!/usr/bin/env python3"
in both Python scripts.

Signed-off-by: Soi Sheng Leong <soishengleong96@gmail.com>